### PR TITLE
fix: Relax required node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
+  - '8'
   - '10'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=10"
+		"node": ">= 8 || >=10"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"


### PR DESCRIPTION
Excuse me if I overlooked something but this seems to be working just fine in node. [URL is fully implemented in node 8](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#2017-05-30-version-800-current-jasnell) which only reaches end of life end of this year. For example netlify is still running with node 8.