### PR TITLE
Fix projects value format in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ Type: `string[]`
 
 The projects to add the issue to.
 
-The project reference format is `user/<project-number>`, for example, if the URL to the project is `https://github.com/sindresorhus/some-repo/projects/3`, the project reference would be `some-repo/3`.
+The project reference format is `user/repo/<project-number>`, for example, if the URL to the project is `https://github.com/sindresorhus/some-repo/projects/3`, the project reference would be `sindresorhus/some-repo/3`.
 
 *Requires the user to have the permission to add projects.*
 


### PR DESCRIPTION
Correct `projects` value format is `user/repo/<project-number>`.

Example:
- `repo/<project-number>`: new issue has no projects.
  - https://github.com/pirosikick/new-github-issue-url-example/issues/new?projects=new-github-issue-url-example%2F1
- `user/repo/<project-number>`: new issue has project 1. 
  - https://github.com/pirosikick/new-github-issue-url-example/issues/new?projects=pirosikick%2Fnew-github-issue-url-example%2F1